### PR TITLE
fixing lint failure for 2.6.6

### DIFF
--- a/oscrypto/_openssl/asymmetric.py
+++ b/oscrypto/_openssl/asymmetric.py
@@ -321,7 +321,7 @@ def generate_pair(algorithm, bit_size=None, curve=None):
                 ))
 
     elif algorithm == 'ec':
-        if curve not in {'secp256r1', 'secp384r1', 'secp521r1'}:
+        if curve not in set(['secp256r1', 'secp384r1', 'secp521r1']):
             raise ValueError(pretty_message(
                 '''
                 curve must be one of "secp256r1", "secp384r1", "secp521r1",


### PR DESCRIPTION
Cannot define a set that way in 2.6.6