### PR TITLE
Fix encoding of unencrypted private keys.

### DIFF
--- a/oscrypto/asymmetric.py
+++ b/oscrypto/asymmetric.py
@@ -328,12 +328,12 @@ def dump_private_key(private_key, passphrase, encoding='pem', target_ms=200):
             'encrypted_data': ciphertext
         }).dump()
 
-        if encoding == 'pem':
-            if passphrase is None:
-                object_type = 'PRIVATE KEY'
-            else:
-                object_type = 'ENCRYPTED PRIVATE KEY'
-            output = asn1crypto.pem.armor(object_type, output)
+    if encoding == 'pem':
+        if passphrase is None:
+            object_type = 'PRIVATE KEY'
+        else:
+            object_type = 'ENCRYPTED PRIVATE KEY'
+        output = asn1crypto.pem.armor(object_type, output)
 
     return output
 

--- a/tests/test_asymmetric.py
+++ b/tests/test_asymmetric.py
@@ -104,10 +104,13 @@ class AsymmetricTests(unittest.TestCase):
     def test_dump_private(self):
         def do_run():
             private = asymmetric.load_private_key(os.path.join(fixtures_dir, 'keys/test.key'))
-            pem_serialized = asymmetric.dump_private_key(private, 'password123', target_ms=20)
-            private_reloaded = asymmetric.load_private_key(pem_serialized, 'password123')
-            self.assertIsInstance(private_reloaded, asymmetric.PrivateKey)
-            self.assertEqual('rsa', private_reloaded.algorithm)
+
+            for password in [None, 'password123']:
+                pem_serialized = asymmetric.dump_private_key(private, password, target_ms=20)
+                private_reloaded = asymmetric.load_private_key(pem_serialized, password)
+                self.assertTrue(pem_serialized.startswith('-----'))
+                self.assertIsInstance(private_reloaded, asymmetric.PrivateKey)
+                self.assertEqual('rsa', private_reloaded.algorithm)
 
         # OpenSSL 0.9.8 doesn't have PBKDF2 implemented in C, thus the dump
         # operation fails since there is no reasonable way to ensure we are

--- a/tests/test_asymmetric.py
+++ b/tests/test_asymmetric.py
@@ -5,6 +5,7 @@ import unittest
 import sys
 import os
 
+from asn1crypto import pem
 from oscrypto import asymmetric, errors
 
 from ._unittest_compat import patch
@@ -108,7 +109,7 @@ class AsymmetricTests(unittest.TestCase):
             for password in [None, 'password123']:
                 pem_serialized = asymmetric.dump_private_key(private, password, target_ms=20)
                 private_reloaded = asymmetric.load_private_key(pem_serialized, password)
-                self.assertTrue(pem_serialized.startswith('-----'))
+                self.assertTrue(pem.detect(pem_serialized))
                 self.assertIsInstance(private_reloaded, asymmetric.PrivateKey)
                 self.assertEqual('rsa', private_reloaded.algorithm)
 


### PR DESCRIPTION
An indentation error in asymmetric.dump_private_key() causes
PEM encoding to be skipped when there's no password.