### PR TITLE
Fixes #35: Pin libcrypto and libssl dylibs only on Catalina

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     working_directory: ~/oscrypto
     macos:
       # This is the last version using macOS 10.12, which has Python 2.6
-      xcode: 9.2.0
+      xcode: 9.0.1
     steps:
       - restore_cache:
           keys:

--- a/oscrypto/_openssl/_libcrypto_cffi.py
+++ b/oscrypto/_openssl/_libcrypto_cffi.py
@@ -1,6 +1,9 @@
 # coding: utf-8
 from __future__ import unicode_literals, division, absolute_import, print_function
 
+import platform
+import sys
+
 import re
 from ctypes.util import find_library
 
@@ -21,10 +24,14 @@ __all__ = [
     'version_info',
 ]
 
-
 libcrypto_path = _backend_config().get('libcrypto_path')
 if libcrypto_path is None:
     libcrypto_path = find_library('crypto')
+    # if we are on catalina, we want to strongly version libcrypto since unversioned libcrypto has a non-stable ABI
+    if sys.platform == 'darwin' and platform.mac_ver()[0].startswith('10.15') and \
+            libcrypto_path.endswith('libcrypto.dylib'):
+        # libcrypto.42.dylib is in libressl-2.6 which as a OpenSSL 1.0.1-compatible API
+        libcrypto_path = libcrypto_path.replace('libcrypto.dylib', 'libcrypto.42.dylib')
 if not libcrypto_path:
     raise LibraryNotFoundError('The library libcrypto could not be found')
 

--- a/oscrypto/_openssl/_libssl_cffi.py
+++ b/oscrypto/_openssl/_libssl_cffi.py
@@ -1,6 +1,9 @@
 # coding: utf-8
 from __future__ import unicode_literals, division, absolute_import, print_function
 
+import platform
+import sys
+
 from ctypes.util import find_library
 
 from .. import _backend_config
@@ -21,6 +24,10 @@ ffi = FFI()
 libssl_path = _backend_config().get('libssl_path')
 if libssl_path is None:
     libssl_path = find_library('ssl')
+    # if we are on catalina, we want to strongly version libssl since unversioned libcrypto has a non-stable ABI
+    if sys.platform == 'darwin' and platform.mac_ver()[0].startswith('10.15') and libssl_path.endswith('libssl.dylib'):
+        # libssl.44.dylib is in libressl-2.6 which as a OpenSSL 1.0.1-compatible API
+        libssl_path = libssl_path.replace('libssl.dylib', 'libssl.44.dylib')
 if not libssl_path:
     raise LibraryNotFoundError('The library libssl could not be found')
 


### PR DESCRIPTION
Here's a possible fix to pin the versions at least on Catalina.