### PR TITLE
add extern keyword on non macOS static variables

### DIFF
--- a/oscrypto/_mac/_core_foundation_cffi.py
+++ b/oscrypto/_mac/_core_foundation_cffi.py
@@ -105,11 +105,11 @@ ffi.cdef("""
     CFIndex CFDictionaryGetKeysAndValues(CFDictionaryRef theDict, const void **keys, const void **values);
     CFTypeID CFGetTypeID(CFTypeRef cf);
 
-    CFAllocatorRef kCFAllocatorDefault;
-    CFArrayCallBacks kCFTypeArrayCallBacks;
-    CFBooleanRef kCFBooleanTrue;
-    CFDictionaryKeyCallBacks kCFTypeDictionaryKeyCallBacks;
-    CFDictionaryValueCallBacks kCFTypeDictionaryValueCallBacks;
+    extern CFAllocatorRef kCFAllocatorDefault;
+    extern CFArrayCallBacks kCFTypeArrayCallBacks;
+    extern CFBooleanRef kCFBooleanTrue;
+    extern CFDictionaryKeyCallBacks kCFTypeDictionaryKeyCallBacks;
+    extern CFDictionaryValueCallBacks kCFTypeDictionaryValueCallBacks;
 """)
 
 core_foundation_path = find_library('CoreFoundation')

--- a/oscrypto/_mac/_security_cffi.py
+++ b/oscrypto/_mac/_security_cffi.py
@@ -171,43 +171,43 @@ ffi.cdef("""
     OSStatus SecPolicySetValue(SecPolicyRef policyRef, const CSSM_DATA *value);
     OSStatus SecTrustEvaluate(SecTrustRef trust, SecTrustResultType *result);
 
-    SecRandomRef kSecRandomDefault;
+        extern SecRandomRef kSecRandomDefault;
 
-    CFStringRef kSecPaddingKey;
-    CFStringRef kSecPaddingPKCS7Key;
-    CFStringRef kSecPaddingPKCS5Key;
-    CFStringRef kSecPaddingPKCS1Key;
-    CFStringRef kSecPaddingOAEPKey;
-    CFStringRef kSecPaddingNoneKey;
-    CFStringRef kSecModeCBCKey;
-    CFStringRef kSecTransformInputAttributeName;
-    CFStringRef kSecDigestTypeAttribute;
-    CFStringRef kSecDigestLengthAttribute;
-    CFStringRef kSecIVKey;
+    extern CFStringRef kSecPaddingKey;
+    extern CFStringRef kSecPaddingPKCS7Key;
+    extern CFStringRef kSecPaddingPKCS5Key;
+    extern CFStringRef kSecPaddingPKCS1Key;
+    extern CFStringRef kSecPaddingOAEPKey;
+    extern CFStringRef kSecPaddingNoneKey;
+    extern CFStringRef kSecModeCBCKey;
+    extern CFStringRef kSecTransformInputAttributeName;
+    extern CFStringRef kSecDigestTypeAttribute;
+    extern CFStringRef kSecDigestLengthAttribute;
+    extern CFStringRef kSecIVKey;
 
-    CFStringRef kSecAttrIsExtractable;
+    extern CFStringRef kSecAttrIsExtractable;
 
-    CFStringRef kSecDigestSHA1;
-    CFStringRef kSecDigestSHA2;
-    CFStringRef kSecDigestMD5;
+    extern CFStringRef kSecDigestSHA1;
+    extern CFStringRef kSecDigestSHA2;
+    extern CFStringRef kSecDigestMD5;
 
-    CFStringRef kSecAttrKeyType;
+    extern CFStringRef kSecAttrKeyType;
 
-    CFTypeRef kSecAttrKeyTypeRSA;
-    CFTypeRef kSecAttrKeyTypeDSA;
-    CFTypeRef kSecAttrKeyTypeECDSA;
+    extern CFTypeRef kSecAttrKeyTypeRSA;
+    extern CFTypeRef kSecAttrKeyTypeDSA;
+    extern CFTypeRef kSecAttrKeyTypeECDSA;
 
-    CFStringRef kSecAttrKeySizeInBits;
-    CFStringRef kSecAttrLabel;
+    extern CFStringRef kSecAttrKeySizeInBits;
+    extern CFStringRef kSecAttrLabel;
 
-    CFTypeRef kSecAttrCanSign;
-    CFTypeRef kSecAttrCanVerify;
+    extern CFTypeRef kSecAttrCanSign;
+    extern CFTypeRef kSecAttrCanVerify;
 
-    CFTypeRef kSecAttrKeyTypeAES;
-    CFTypeRef kSecAttrKeyTypeRC4;
-    CFTypeRef kSecAttrKeyTypeRC2;
-    CFTypeRef kSecAttrKeyType3DES;
-    CFTypeRef kSecAttrKeyTypeDES;
+    extern CFTypeRef kSecAttrKeyTypeAES;
+    extern CFTypeRef kSecAttrKeyTypeRC4;
+    extern CFTypeRef kSecAttrKeyTypeRC2;
+    extern CFTypeRef kSecAttrKeyType3DES;
+    extern CFTypeRef kSecAttrKeyTypeDES;
 """)
 
 if version_info < (10, 8):

--- a/oscrypto/_mac/_security_cffi.py
+++ b/oscrypto/_mac/_security_cffi.py
@@ -171,7 +171,7 @@ ffi.cdef("""
     OSStatus SecPolicySetValue(SecPolicyRef policyRef, const CSSM_DATA *value);
     OSStatus SecTrustEvaluate(SecTrustRef trust, SecTrustResultType *result);
 
-        extern SecRandomRef kSecRandomDefault;
+    extern SecRandomRef kSecRandomDefault;
 
     extern CFStringRef kSecPaddingKey;
     extern CFStringRef kSecPaddingPKCS7Key;


### PR DESCRIPTION
Closes https://github.com/wbond/oscrypto/issues/34.

Added extern keyword to macOS SDK non-static variables that pop up in warnings.