### PR TITLE
fixes compatibility with macos big sur.

### DIFF
--- a/oscrypto/_ffi.py
+++ b/oscrypto/_ffi.py
@@ -393,7 +393,7 @@ else:
 def get_library(name, dylib_name, version):
     """
     Retrieve the C library path with special handling for macOS.
-    
+
     :param name:
         The library to search the system for.
     :param dylib_name:

--- a/oscrypto/_ffi.py
+++ b/oscrypto/_ffi.py
@@ -7,6 +7,9 @@ Exceptions and compatibility shims for consistently using ctypes and cffi
 from __future__ import unicode_literals, division, absolute_import, print_function
 
 import sys
+import platform
+
+from ctypes.util import find_library
 
 from . import ffi
 from ._types import str_cls, byte_cls, int_types, bytes_to_list
@@ -26,6 +29,7 @@ __all__ = [
     'deref',
     'errno',
     'FFIEngineError',
+    'get_library',
     'is_null',
     'native',
     'new',
@@ -384,6 +388,31 @@ else:
         return getattr(library, signature_type)(func)
 
     engine = 'ctypes'
+
+
+def get_library(name, unversioned, fallback):
+    """
+    Retrieves the C library, falling back to a specified library if one is not found
+
+    :param name:
+        The library to search the system for
+
+    :param unversioned:
+        The unversioned library we don't want to use
+
+    :param fallback:
+        Fallback library when we don't find a suitable library to use
+
+    :return:
+        Path to the library
+    """
+    library = find_library(name)
+    if not library and sys.platform == 'darwin' and tuple(map(int,  platform.mac_ver()[0].split('.'))) >= (10, 16):
+        library == fallback
+    elif sys.platform == 'darwin' and tuple(map(int,  platform.mac_ver()[0].split('.'))) >= (10, 15) and \
+            library == unversioned:
+        library = fallback
+    return library
 
 
 class FFIEngineError(Exception):

--- a/oscrypto/_ffi.py
+++ b/oscrypto/_ffi.py
@@ -407,8 +407,8 @@ def get_library(name, dylib_name, version):
     """
     library = find_library(name)
     if sys.platform == 'darwin':
-        unversioned = '/usr/lib/{}'.format(dylib_name)
-        versioned = unversioned.replace('.dylib', '.{}.dylib'.format(version))
+        unversioned = '/usr/lib/%s' % dylib_name
+        versioned = unversioned.replace('.dylib', '.%s.dylib' % version)
         mac_ver = tuple(map(int, platform.mac_ver()[0].split('.')))
         if not library and mac_ver >= (10, 16):
             # On macOS 10.16+, find_library doesn't work, so we set a static path

--- a/oscrypto/_mac/_common_crypto_cffi.py
+++ b/oscrypto/_mac/_common_crypto_cffi.py
@@ -23,5 +23,7 @@ ffi.cdef("""
                     char *derivedKey, size_t derivedKeyLen);
 """)
 
-CommonCrypto = ffi.dlopen('/usr/lib/system/libcommonCrypto.dylib')
+common_crypto_path = '/usr/lib/system/libcommonCrypto.dylib'
+
+CommonCrypto = ffi.dlopen(common_crypto_path)
 register_ffi(CommonCrypto, ffi)

--- a/oscrypto/_mac/_common_crypto_ctypes.py
+++ b/oscrypto/_mac/_common_crypto_ctypes.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals, division, absolute_import, print_functi
 from ctypes import CDLL, c_uint32, c_char_p, c_size_t, c_int, c_uint
 
 from .._ffi import FFIEngineError
-from ..errors import LibraryNotFoundError
 
 
 __all__ = [
@@ -13,8 +12,6 @@ __all__ = [
 
 
 common_crypto_path = '/usr/lib/system/libcommonCrypto.dylib'
-if not common_crypto_path:
-    raise LibraryNotFoundError('The library libcommonCrypto could not be found')
 
 CommonCrypto = CDLL(common_crypto_path, use_errno=True)
 

--- a/oscrypto/_mac/_core_foundation_cffi.py
+++ b/oscrypto/_mac/_core_foundation_cffi.py
@@ -109,7 +109,7 @@ ffi.cdef("""
     extern CFDictionaryValueCallBacks kCFTypeDictionaryValueCallBacks;
 """)
 
-core_foundation_path = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
+core_foundation_path = '/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation'
 
 CoreFoundation = ffi.dlopen(core_foundation_path)
 register_ffi(CoreFoundation, ffi)

--- a/oscrypto/_mac/_core_foundation_cffi.py
+++ b/oscrypto/_mac/_core_foundation_cffi.py
@@ -1,8 +1,6 @@
 # coding: utf-8
 from __future__ import unicode_literals, division, absolute_import, print_function
 
-from ctypes.util import find_library
-
 from .._ffi import (
     buffer_from_bytes,
     byte_string_from_buffer,
@@ -112,9 +110,7 @@ ffi.cdef("""
     extern CFDictionaryValueCallBacks kCFTypeDictionaryValueCallBacks;
 """)
 
-core_foundation_path = find_library('CoreFoundation')
-if not core_foundation_path:
-    raise LibraryNotFoundError('The library CoreFoundation could not be found')
+core_foundation_path = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
 
 CoreFoundation = ffi.dlopen(core_foundation_path)
 register_ffi(CoreFoundation, ffi)

--- a/oscrypto/_mac/_core_foundation_cffi.py
+++ b/oscrypto/_mac/_core_foundation_cffi.py
@@ -9,7 +9,6 @@ from .._ffi import (
     new,
     register_ffi,
 )
-from ..errors import LibraryNotFoundError
 
 from cffi import FFI
 

--- a/oscrypto/_mac/_core_foundation_ctypes.py
+++ b/oscrypto/_mac/_core_foundation_ctypes.py
@@ -14,7 +14,7 @@ __all__ = [
 ]
 
 
-core_foundation_path = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
+core_foundation_path = '/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation'
 
 CoreFoundation = CDLL(core_foundation_path, use_errno=True)
 

--- a/oscrypto/_mac/_core_foundation_ctypes.py
+++ b/oscrypto/_mac/_core_foundation_ctypes.py
@@ -6,7 +6,6 @@ from ctypes import CDLL, string_at, cast, POINTER, byref
 import ctypes
 
 from .._ffi import FFIEngineError, buffer_from_bytes, byte_string_from_buffer
-from ..errors import LibraryNotFoundError
 
 
 __all__ = [

--- a/oscrypto/_mac/_core_foundation_ctypes.py
+++ b/oscrypto/_mac/_core_foundation_ctypes.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 from __future__ import unicode_literals, division, absolute_import, print_function
 
-from ctypes.util import find_library
 from ctypes import c_void_p, c_long, c_uint32, c_char_p, c_byte, c_ulong, c_bool
 from ctypes import CDLL, string_at, cast, POINTER, byref
 import ctypes
@@ -16,9 +15,7 @@ __all__ = [
 ]
 
 
-core_foundation_path = find_library('CoreFoundation')
-if not core_foundation_path:
-    raise LibraryNotFoundError('The library CoreFoundation could not be found')
+core_foundation_path = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
 
 CoreFoundation = CDLL(core_foundation_path, use_errno=True)
 

--- a/oscrypto/_mac/_security_cffi.py
+++ b/oscrypto/_mac/_security_cffi.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals, division, absolute_import, print_functi
 import platform
 
 from .._ffi import register_ffi
-from ..errors import LibraryNotFoundError
 
 from cffi import FFI
 

--- a/oscrypto/_mac/_security_cffi.py
+++ b/oscrypto/_mac/_security_cffi.py
@@ -232,7 +232,7 @@ else:
         OSStatus SSLSetProtocolVersionMax(SSLContextRef context, SSLProtocol maxVersion);
     """)
 
-security_path = "/System/Library/Frameworks/Security.framework/Security"
+security_path = '/System/Library/Frameworks/Security.framework/Security'
 
 Security = ffi.dlopen(security_path)
 register_ffi(Security, ffi)

--- a/oscrypto/_mac/_security_cffi.py
+++ b/oscrypto/_mac/_security_cffi.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals, division, absolute_import, print_function
 
 import platform
-from ctypes.util import find_library
 
 from .._ffi import register_ffi
 from ..errors import LibraryNotFoundError
@@ -234,9 +233,7 @@ else:
         OSStatus SSLSetProtocolVersionMax(SSLContextRef context, SSLProtocol maxVersion);
     """)
 
-security_path = find_library('Security')
-if not security_path:
-    raise LibraryNotFoundError('The library Security could not be found')
+security_path = "/System/Library/Frameworks/Security.framework/Security"
 
 Security = ffi.dlopen(security_path)
 register_ffi(Security, ffi)

--- a/oscrypto/_mac/_security_ctypes.py
+++ b/oscrypto/_mac/_security_ctypes.py
@@ -21,7 +21,7 @@ version_info = tuple(map(int,  platform.mac_ver()[0].split('.')))
 if version_info < (10, 7):
     raise OSError('Only OS X 10.7 and newer are supported, not %s.%s' % (version_info[0], version_info[1]))
 
-security_path = "/System/Library/Frameworks/Security.framework/Security"
+security_path = '/System/Library/Frameworks/Security.framework/Security'
 
 Security = CDLL(security_path, use_errno=True)
 

--- a/oscrypto/_mac/_security_ctypes.py
+++ b/oscrypto/_mac/_security_ctypes.py
@@ -6,7 +6,6 @@ from ctypes import c_void_p, c_int32, c_char_p, c_size_t, c_byte, c_int, c_uint3
 from ctypes import CDLL, POINTER, CFUNCTYPE, Structure
 
 from .._ffi import FFIEngineError
-from ..errors import LibraryNotFoundError
 
 
 __all__ = [

--- a/oscrypto/_mac/_security_ctypes.py
+++ b/oscrypto/_mac/_security_ctypes.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals, division, absolute_import, print_function
 
 import platform
-from ctypes.util import find_library
 from ctypes import c_void_p, c_int32, c_char_p, c_size_t, c_byte, c_int, c_uint32, c_uint64, c_ulong, c_long, c_bool
 from ctypes import CDLL, POINTER, CFUNCTYPE, Structure
 
@@ -18,14 +17,12 @@ __all__ = [
 
 
 version = platform.mac_ver()[0]
-version_info = tuple(map(int, version.split('.')))
+version_info = tuple(map(int,  platform.mac_ver()[0].split('.')))
 
 if version_info < (10, 7):
     raise OSError('Only OS X 10.7 and newer are supported, not %s.%s' % (version_info[0], version_info[1]))
 
-security_path = find_library('Security')
-if not security_path:
-    raise LibraryNotFoundError('The library Security could not be found')
+security_path = "/System/Library/Frameworks/Security.framework/Security"
 
 Security = CDLL(security_path, use_errno=True)
 

--- a/oscrypto/_openssl/_libcrypto_cffi.py
+++ b/oscrypto/_openssl/_libcrypto_cffi.py
@@ -22,7 +22,7 @@ __all__ = [
 
 libcrypto_path = _backend_config().get('libcrypto_path')
 if libcrypto_path is None:
-    libcrypto_path = get_library('crypto', '/usr/lib/libcrypto.dylib', '/usr/lib/libcrypto.42.dylib')
+    libcrypto_path = get_library('crypto', 'libcrypto.dylib', '42')
 if not libcrypto_path:
     raise LibraryNotFoundError('The library libcrypto could not be found')
 

--- a/oscrypto/_openssl/_libcrypto_cffi.py
+++ b/oscrypto/_openssl/_libcrypto_cffi.py
@@ -1,13 +1,10 @@
 # coding: utf-8
 from __future__ import unicode_literals, division, absolute_import, print_function
 
-import platform
-import sys
-
 import re
-from ctypes.util import find_library
 
 from .. import _backend_config
+from ..util import get_library
 from .._errors import pretty_message
 from .._ffi import register_ffi
 from ..errors import LibraryNotFoundError
@@ -26,15 +23,7 @@ __all__ = [
 
 libcrypto_path = _backend_config().get('libcrypto_path')
 if libcrypto_path is None:
-    libcrypto_path = find_library('crypto')
-    # If we are on macOS 10.16+, find_library doesn't work, so we set a static path
-    if not libcrypto_path and sys.platform == 'darwin' and \
-            tuple(map(int,  platform.mac_ver()[0].split('.'))) >= (10, 16):
-        libcrypto_path == '/usr/lib/libcrypto.42.dylib'
-    # if we are on macOS 10.15+, we want to strongly version libcrypto since unversioned libcrypto has a non-stable ABI
-    if sys.platform == 'darwin' and tuple(map(int,  platform.mac_ver()[0].split('.'))) >= (10, 15) and \
-            libcrypto_path == '/usr/lib/libcrypto.dylib':
-        libcrypto_path = libcrypto_path.replace('libcrypto.dylib', 'libcrypto.42.dylib')
+    libcrypto_path = get_library('crypto', '/usr/lib/libcrypto.dylib', '/usr/lib/libcrypto.42.dylib')
 if not libcrypto_path:
     raise LibraryNotFoundError('The library libcrypto could not be found')
 

--- a/oscrypto/_openssl/_libcrypto_cffi.py
+++ b/oscrypto/_openssl/_libcrypto_cffi.py
@@ -4,8 +4,8 @@ from __future__ import unicode_literals, division, absolute_import, print_functi
 import re
 
 from .. import _backend_config
-from ..util import get_library
 from .._errors import pretty_message
+from .._ffi import get_library
 from .._ffi import register_ffi
 from ..errors import LibraryNotFoundError
 

--- a/oscrypto/_openssl/_libcrypto_cffi.py
+++ b/oscrypto/_openssl/_libcrypto_cffi.py
@@ -27,10 +27,12 @@ __all__ = [
 libcrypto_path = _backend_config().get('libcrypto_path')
 if libcrypto_path is None:
     libcrypto_path = find_library('crypto')
+    # If we are on macOS 10.16+, find_library doesn't work, so we set a static path
+    if sys.platform == 'darwin' and tuple(map(int,  platform.mac_ver()[0].split('.'))) >= (10, 16):
+        libcrypto_path == '/usr/lib/libcrypto.42.dylib'
     # if we are on macOS 10.15+, we want to strongly version libcrypto since unversioned libcrypto has a non-stable ABI
-    if sys.platform == 'darwin' and list(map(int, platform.mac_ver()[0].split('.')))[1] >= 15 and \
+    if sys.platform == 'darwin' and tuple(map(int,  platform.mac_ver()[0].split('.'))) >= (10, 15) and \
             libcrypto_path == '/usr/lib/libcrypto.dylib':
-        # libcrypto.42.dylib is in libressl-2.6 which as a OpenSSL 1.0.1-compatible API
         libcrypto_path = libcrypto_path.replace('libcrypto.dylib', 'libcrypto.42.dylib')
 if not libcrypto_path:
     raise LibraryNotFoundError('The library libcrypto could not be found')

--- a/oscrypto/_openssl/_libcrypto_cffi.py
+++ b/oscrypto/_openssl/_libcrypto_cffi.py
@@ -5,8 +5,7 @@ import re
 
 from .. import _backend_config
 from .._errors import pretty_message
-from .._ffi import get_library
-from .._ffi import register_ffi
+from .._ffi import get_library, register_ffi
 from ..errors import LibraryNotFoundError
 
 from cffi import FFI

--- a/oscrypto/_openssl/_libcrypto_cffi.py
+++ b/oscrypto/_openssl/_libcrypto_cffi.py
@@ -28,7 +28,8 @@ libcrypto_path = _backend_config().get('libcrypto_path')
 if libcrypto_path is None:
     libcrypto_path = find_library('crypto')
     # If we are on macOS 10.16+, find_library doesn't work, so we set a static path
-    if sys.platform == 'darwin' and tuple(map(int,  platform.mac_ver()[0].split('.'))) >= (10, 16):
+    if not libcrypto_path and sys.platform == 'darwin' and \
+            tuple(map(int,  platform.mac_ver()[0].split('.'))) >= (10, 16):
         libcrypto_path == '/usr/lib/libcrypto.42.dylib'
     # if we are on macOS 10.15+, we want to strongly version libcrypto since unversioned libcrypto has a non-stable ABI
     if sys.platform == 'darwin' and tuple(map(int,  platform.mac_ver()[0].split('.'))) >= (10, 15) and \

--- a/oscrypto/_openssl/_libcrypto_ctypes.py
+++ b/oscrypto/_openssl/_libcrypto_ctypes.py
@@ -26,8 +26,11 @@ __all__ = [
 libcrypto_path = _backend_config().get('libcrypto_path')
 if libcrypto_path is None:
     libcrypto_path = find_library('crypto')
+    # If we are on macOS 10.16+, find_library doesn't work, so we set a static path
+    if sys.platform == 'darwin' and tuple(map(int,  platform.mac_ver()[0].split('.'))) >= (10, 16):
+        libcrypto_path == '/usr/lib/libcrypto.42.dylib'
     # if we are on macOS 10.15+, we want to strongly version libcrypto since unversioned libcrypto has a non-stable ABI
-    if sys.platform == 'darwin' and list(map(int, platform.mac_ver()[0].split('.')))[1] >= 15 and \
+    if sys.platform == 'darwin' and tuple(map(int,  platform.mac_ver()[0].split('.'))) >= (10, 15) and \
             libcrypto_path == '/usr/lib/libcrypto.dylib':
         # libcrypto.42.dylib is in libressl-2.6 which as a OpenSSL 1.0.1-compatible API
         libcrypto_path = libcrypto_path.replace('libcrypto.dylib', 'libcrypto.42.dylib')

--- a/oscrypto/_openssl/_libcrypto_ctypes.py
+++ b/oscrypto/_openssl/_libcrypto_ctypes.py
@@ -23,7 +23,7 @@ __all__ = [
 
 libcrypto_path = _backend_config().get('libcrypto_path')
 if libcrypto_path is None:
-    libcrypto_path = get_library('crypto', '/usr/lib/libcrypto.dylib', '/usr/lib/libcrypto.42.dylib')
+    libcrypto_path = get_library('crypto', 'libcrypto.dylib', '42')
 if not libcrypto_path:
     raise LibraryNotFoundError('The library libcrypto could not be found')
 

--- a/oscrypto/_openssl/_libcrypto_ctypes.py
+++ b/oscrypto/_openssl/_libcrypto_ctypes.py
@@ -6,8 +6,8 @@ import re
 from ctypes import CDLL, c_void_p, c_char_p, c_int, c_ulong, c_uint, c_long, c_size_t, POINTER
 
 from .. import _backend_config
-from ..util import get_library
 from .._errors import pretty_message
+from .._ffi import get_library
 from .._ffi import FFIEngineError
 from ..errors import LibraryNotFoundError
 

--- a/oscrypto/_openssl/_libcrypto_ctypes.py
+++ b/oscrypto/_openssl/_libcrypto_ctypes.py
@@ -7,8 +7,7 @@ from ctypes import CDLL, c_void_p, c_char_p, c_int, c_ulong, c_uint, c_long, c_s
 
 from .. import _backend_config
 from .._errors import pretty_message
-from .._ffi import get_library
-from .._ffi import FFIEngineError
+from .._ffi import FFIEngineError, get_library
 from ..errors import LibraryNotFoundError
 
 

--- a/oscrypto/_openssl/_libcrypto_ctypes.py
+++ b/oscrypto/_openssl/_libcrypto_ctypes.py
@@ -1,13 +1,12 @@
 # coding: utf-8
 from __future__ import unicode_literals, division, absolute_import, print_function
 
-import platform
 import re
-import sys
-from ctypes.util import find_library
+
 from ctypes import CDLL, c_void_p, c_char_p, c_int, c_ulong, c_uint, c_long, c_size_t, POINTER
 
 from .. import _backend_config
+from ..util import get_library
 from .._errors import pretty_message
 from .._ffi import FFIEngineError
 from ..errors import LibraryNotFoundError
@@ -25,16 +24,7 @@ __all__ = [
 
 libcrypto_path = _backend_config().get('libcrypto_path')
 if libcrypto_path is None:
-    libcrypto_path = find_library('crypto')
-    # If we are on macOS 10.16+, find_library doesn't work, so we set a static path
-    if not libcrypto_path and sys.platform == 'darwin' and \
-            tuple(map(int,  platform.mac_ver()[0].split('.'))) >= (10, 16):
-        libcrypto_path == '/usr/lib/libcrypto.42.dylib'
-    # if we are on macOS 10.15+, we want to strongly version libcrypto since unversioned libcrypto has a non-stable ABI
-    if sys.platform == 'darwin' and tuple(map(int,  platform.mac_ver()[0].split('.'))) >= (10, 15) and \
-            libcrypto_path == '/usr/lib/libcrypto.dylib':
-        # libcrypto.42.dylib is in libressl-2.6 which as a OpenSSL 1.0.1-compatible API
-        libcrypto_path = libcrypto_path.replace('libcrypto.dylib', 'libcrypto.42.dylib')
+    libcrypto_path = get_library('crypto', '/usr/lib/libcrypto.dylib', '/usr/lib/libcrypto.42.dylib')
 if not libcrypto_path:
     raise LibraryNotFoundError('The library libcrypto could not be found')
 

--- a/oscrypto/_openssl/_libcrypto_ctypes.py
+++ b/oscrypto/_openssl/_libcrypto_ctypes.py
@@ -27,7 +27,8 @@ libcrypto_path = _backend_config().get('libcrypto_path')
 if libcrypto_path is None:
     libcrypto_path = find_library('crypto')
     # If we are on macOS 10.16+, find_library doesn't work, so we set a static path
-    if sys.platform == 'darwin' and tuple(map(int,  platform.mac_ver()[0].split('.'))) >= (10, 16):
+    if not libcrypto_path and sys.platform == 'darwin' and \
+            tuple(map(int,  platform.mac_ver()[0].split('.'))) >= (10, 16):
         libcrypto_path == '/usr/lib/libcrypto.42.dylib'
     # if we are on macOS 10.15+, we want to strongly version libcrypto since unversioned libcrypto has a non-stable ABI
     if sys.platform == 'darwin' and tuple(map(int,  platform.mac_ver()[0].split('.'))) >= (10, 15) and \

--- a/oscrypto/_openssl/_libssl_cffi.py
+++ b/oscrypto/_openssl/_libssl_cffi.py
@@ -2,8 +2,7 @@
 from __future__ import unicode_literals, division, absolute_import, print_function
 
 from .. import _backend_config
-from .._ffi import get_library
-from .._ffi import register_ffi
+from .._ffi import get_library, register_ffi
 from ..errors import LibraryNotFoundError
 from ._libcrypto import libcrypto_version_info
 

--- a/oscrypto/_openssl/_libssl_cffi.py
+++ b/oscrypto/_openssl/_libssl_cffi.py
@@ -25,7 +25,8 @@ libssl_path = _backend_config().get('libssl_path')
 if libssl_path is None:
     libssl_path = find_library('ssl')
     # If we are on macOS 10.16+, find_library doesn't work, so we set a static path
-    if sys.platform == 'darwin' and tuple(map(int,  platform.mac_ver()[0].split('.'))) >= (10, 16):
+    if not libssl_path and sys.platform == 'darwin' and \
+            tuple(map(int,  platform.mac_ver()[0].split('.'))) >= (10, 16):
         libssl_path = '/usr/lib/libssl.44.dylib'
     # if we are on macOS 10.15+, we want to strongly version libssl since unversioned libcrypto has a non-stable ABI
     if sys.platform == 'darwin' and list(map(int, platform.mac_ver()[0].split('.')))[1] >= 15 and \

--- a/oscrypto/_openssl/_libssl_cffi.py
+++ b/oscrypto/_openssl/_libssl_cffi.py
@@ -18,7 +18,7 @@ ffi = FFI()
 
 libssl_path = _backend_config().get('libssl_path')
 if libssl_path is None:
-    libssl_path = get_library('ssl', '/usr/lib/libssl.dylib', '/usr/lib/libssl.44.dylib')
+    libssl_path = get_library('ssl', 'libssl', '44')
 if not libssl_path:
     raise LibraryNotFoundError('The library libssl could not be found')
 

--- a/oscrypto/_openssl/_libssl_cffi.py
+++ b/oscrypto/_openssl/_libssl_cffi.py
@@ -26,7 +26,7 @@ if libssl_path is None:
     libssl_path = find_library('ssl')
     # If we are on macOS 10.16+, find_library doesn't work, so we set a static path
     if sys.platform == 'darwin' and tuple(map(int,  platform.mac_ver()[0].split('.'))) >= (10, 16):
-       libssl_path = '/usr/lib/libssl.44.dylib'
+        libssl_path = '/usr/lib/libssl.44.dylib'
     # if we are on macOS 10.15+, we want to strongly version libssl since unversioned libcrypto has a non-stable ABI
     if sys.platform == 'darwin' and list(map(int, platform.mac_ver()[0].split('.')))[1] >= 15 and \
             libssl_path == '/usr/lib/libssl.dylib':

--- a/oscrypto/_openssl/_libssl_cffi.py
+++ b/oscrypto/_openssl/_libssl_cffi.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals, division, absolute_import, print_function
 
 from .. import _backend_config
-from ..util import get_library
+from .._ffi import get_library
 from .._ffi import register_ffi
 from ..errors import LibraryNotFoundError
 from ._libcrypto import libcrypto_version_info

--- a/oscrypto/_openssl/_libssl_cffi.py
+++ b/oscrypto/_openssl/_libssl_cffi.py
@@ -24,6 +24,9 @@ ffi = FFI()
 libssl_path = _backend_config().get('libssl_path')
 if libssl_path is None:
     libssl_path = find_library('ssl')
+    # If we are on macOS 10.16+, find_library doesn't work, so we set a static path
+    if sys.platform == 'darwin' and tuple(map(int,  platform.mac_ver()[0].split('.'))) >= (10, 16):
+       libssl_path = '/usr/lib/libssl.44.dylib'
     # if we are on macOS 10.15+, we want to strongly version libssl since unversioned libcrypto has a non-stable ABI
     if sys.platform == 'darwin' and list(map(int, platform.mac_ver()[0].split('.')))[1] >= 15 and \
             libssl_path == '/usr/lib/libssl.dylib':

--- a/oscrypto/_openssl/_libssl_cffi.py
+++ b/oscrypto/_openssl/_libssl_cffi.py
@@ -1,12 +1,8 @@
 # coding: utf-8
 from __future__ import unicode_literals, division, absolute_import, print_function
 
-import platform
-import sys
-
-from ctypes.util import find_library
-
 from .. import _backend_config
+from ..util import get_library
 from .._ffi import register_ffi
 from ..errors import LibraryNotFoundError
 from ._libcrypto import libcrypto_version_info
@@ -23,16 +19,7 @@ ffi = FFI()
 
 libssl_path = _backend_config().get('libssl_path')
 if libssl_path is None:
-    libssl_path = find_library('ssl')
-    # If we are on macOS 10.16+, find_library doesn't work, so we set a static path
-    if not libssl_path and sys.platform == 'darwin' and \
-            tuple(map(int,  platform.mac_ver()[0].split('.'))) >= (10, 16):
-        libssl_path = '/usr/lib/libssl.44.dylib'
-    # if we are on macOS 10.15+, we want to strongly version libssl since unversioned libcrypto has a non-stable ABI
-    if sys.platform == 'darwin' and list(map(int, platform.mac_ver()[0].split('.')))[1] >= 15 and \
-            libssl_path == '/usr/lib/libssl.dylib':
-        # libssl.44.dylib is in libressl-2.6 which as a OpenSSL 1.0.1-compatible API
-        libssl_path = libssl_path.replace('libssl.dylib', 'libssl.44.dylib')
+    libssl_path = get_library('ssl', '/usr/lib/libssl.dylib', '/usr/lib/libssl.44.dylib')
 if not libssl_path:
     raise LibraryNotFoundError('The library libssl could not be found')
 

--- a/oscrypto/_openssl/_libssl_ctypes.py
+++ b/oscrypto/_openssl/_libssl_ctypes.py
@@ -21,7 +21,8 @@ libssl_path = _backend_config().get('libssl_path')
 if libssl_path is None:
     libssl_path = find_library('ssl')
     # If we are on macOS 10.16+, find_library doesn't work, so we set a static path
-    if sys.platform == 'darwin' and tuple(map(int,  platform.mac_ver()[0].split('.'))) >= (10, 16):
+    if not libssl_path and sys.platform == 'darwin' and \
+            tuple(map(int,  platform.mac_ver()[0].split('.'))) >= (10, 16):
         libssl_path = '/usr/lib/libssl.44.dylib'
     # if we are on macOS 10.15+, we want to strongly version libssl since unversioned libcrypto has a non-stable ABI
     if sys.platform == 'darwin' and list(map(int, platform.mac_ver()[0].split('.')))[1] >= 15 and \

--- a/oscrypto/_openssl/_libssl_ctypes.py
+++ b/oscrypto/_openssl/_libssl_ctypes.py
@@ -20,6 +20,9 @@ __all__ = [
 libssl_path = _backend_config().get('libssl_path')
 if libssl_path is None:
     libssl_path = find_library('ssl')
+    # If we are on macOS 10.16+, find_library doesn't work, so we set a static path
+    if sys.platform == 'darwin' and tuple(map(int,  platform.mac_ver()[0].split('.'))) >= (10, 16):
+       libssl_path = '/usr/lib/libssl.44.dylib'
     # if we are on macOS 10.15+, we want to strongly version libssl since unversioned libcrypto has a non-stable ABI
     if sys.platform == 'darwin' and list(map(int, platform.mac_ver()[0].split('.')))[1] >= 15 and \
             libssl_path == '/usr/lib/libssl.dylib':

--- a/oscrypto/_openssl/_libssl_ctypes.py
+++ b/oscrypto/_openssl/_libssl_ctypes.py
@@ -1,12 +1,10 @@
 # coding: utf-8
 from __future__ import unicode_literals, division, absolute_import, print_function
 
-import platform
-import sys
-from ctypes.util import find_library
 from ctypes import CDLL, CFUNCTYPE, POINTER, c_void_p, c_char_p, c_int, c_size_t, c_long
 
 from .. import _backend_config
+from ..util import get_library
 from .._ffi import FFIEngineError
 from ..errors import LibraryNotFoundError
 from ._libcrypto import libcrypto_version_info
@@ -19,16 +17,7 @@ __all__ = [
 
 libssl_path = _backend_config().get('libssl_path')
 if libssl_path is None:
-    libssl_path = find_library('ssl')
-    # If we are on macOS 10.16+, find_library doesn't work, so we set a static path
-    if not libssl_path and sys.platform == 'darwin' and \
-            tuple(map(int,  platform.mac_ver()[0].split('.'))) >= (10, 16):
-        libssl_path = '/usr/lib/libssl.44.dylib'
-    # if we are on macOS 10.15+, we want to strongly version libssl since unversioned libcrypto has a non-stable ABI
-    if sys.platform == 'darwin' and list(map(int, platform.mac_ver()[0].split('.')))[1] >= 15 and \
-            libssl_path == '/usr/lib/libssl.dylib':
-        # libssl.44.dylib is in libressl-2.6 which as a OpenSSL 1.0.1-compatible API
-        libssl_path = libssl_path.replace('libssl.dylib', 'libssl.44.dylib')
+    libssl_path = get_library('ssl', '/usr/lib/libssl.dylib', '/usr/lib/libssl.44.dylib')
 if not libssl_path:
     raise LibraryNotFoundError('The library libssl could not be found')
 

--- a/oscrypto/_openssl/_libssl_ctypes.py
+++ b/oscrypto/_openssl/_libssl_ctypes.py
@@ -4,8 +4,7 @@ from __future__ import unicode_literals, division, absolute_import, print_functi
 from ctypes import CDLL, CFUNCTYPE, POINTER, c_void_p, c_char_p, c_int, c_size_t, c_long
 
 from .. import _backend_config
-from .._ffi import get_library
-from .._ffi import FFIEngineError
+from .._ffi import FFIEngineError, get_library
 from ..errors import LibraryNotFoundError
 from ._libcrypto import libcrypto_version_info
 

--- a/oscrypto/_openssl/_libssl_ctypes.py
+++ b/oscrypto/_openssl/_libssl_ctypes.py
@@ -16,7 +16,7 @@ __all__ = [
 
 libssl_path = _backend_config().get('libssl_path')
 if libssl_path is None:
-    libssl_path = get_library('ssl', '/usr/lib/libssl.dylib', '/usr/lib/libssl.44.dylib')
+    libssl_path = get_library('ssl', 'libssl', '44')
 if not libssl_path:
     raise LibraryNotFoundError('The library libssl could not be found')
 

--- a/oscrypto/_openssl/_libssl_ctypes.py
+++ b/oscrypto/_openssl/_libssl_ctypes.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals, division, absolute_import, print_functi
 from ctypes import CDLL, CFUNCTYPE, POINTER, c_void_p, c_char_p, c_int, c_size_t, c_long
 
 from .. import _backend_config
-from ..util import get_library
+from .._ffi import get_library
 from .._ffi import FFIEngineError
 from ..errors import LibraryNotFoundError
 from ._libcrypto import libcrypto_version_info

--- a/oscrypto/_openssl/_libssl_ctypes.py
+++ b/oscrypto/_openssl/_libssl_ctypes.py
@@ -22,7 +22,7 @@ if libssl_path is None:
     libssl_path = find_library('ssl')
     # If we are on macOS 10.16+, find_library doesn't work, so we set a static path
     if sys.platform == 'darwin' and tuple(map(int,  platform.mac_ver()[0].split('.'))) >= (10, 16):
-       libssl_path = '/usr/lib/libssl.44.dylib'
+        libssl_path = '/usr/lib/libssl.44.dylib'
     # if we are on macOS 10.15+, we want to strongly version libssl since unversioned libcrypto has a non-stable ABI
     if sys.platform == 'darwin' and list(map(int, platform.mac_ver()[0].split('.')))[1] >= 15 and \
             libssl_path == '/usr/lib/libssl.dylib':

--- a/oscrypto/util.py
+++ b/oscrypto/util.py
@@ -2,6 +2,9 @@
 from __future__ import unicode_literals, division, absolute_import, print_function
 
 import sys
+import platform
+
+from ctypes.util import find_library
 
 from ._errors import pretty_message
 from ._types import type_name, byte_cls
@@ -17,6 +20,7 @@ else:
 __all__ = [
     'constant_compare',
     'rand_bytes',
+    'get_library',
 ]
 
 
@@ -61,3 +65,28 @@ def constant_compare(a, b):
     for x, y in zip(a, b):
         result |= x ^ y
     return result == 0
+
+
+def get_library(name, unversioned, fallback):
+    """
+    Retrieves the C library, falling back to a specified library if one is not found
+
+    :param name:
+        The library to search the system for
+
+    :param unversioned:
+        The unversioned library we don't want to use
+
+    :param fallback:
+        Fallback library when we don't find a suitable library to use
+
+    :return:
+        Path to the library
+    """
+    library = find_library(name)
+    if not library and sys.platform == 'darwin' and tuple(map(int,  platform.mac_ver()[0].split('.'))) >= (10, 16):
+        library == fallback
+    elif sys.platform == 'darwin' and tuple(map(int,  platform.mac_ver()[0].split('.'))) >= (10, 15) and \
+            library == unversioned:
+        library = fallback
+    return library

--- a/oscrypto/util.py
+++ b/oscrypto/util.py
@@ -2,9 +2,6 @@
 from __future__ import unicode_literals, division, absolute_import, print_function
 
 import sys
-import platform
-
-from ctypes.util import find_library
 
 from ._errors import pretty_message
 from ._types import type_name, byte_cls
@@ -20,7 +17,6 @@ else:
 __all__ = [
     'constant_compare',
     'rand_bytes',
-    'get_library',
 ]
 
 
@@ -65,28 +61,3 @@ def constant_compare(a, b):
     for x, y in zip(a, b):
         result |= x ^ y
     return result == 0
-
-
-def get_library(name, unversioned, fallback):
-    """
-    Retrieves the C library, falling back to a specified library if one is not found
-
-    :param name:
-        The library to search the system for
-
-    :param unversioned:
-        The unversioned library we don't want to use
-
-    :param fallback:
-        Fallback library when we don't find a suitable library to use
-
-    :return:
-        Path to the library
-    """
-    library = find_library(name)
-    if not library and sys.platform == 'darwin' and tuple(map(int,  platform.mac_ver()[0].split('.'))) >= (10, 16):
-        library == fallback
-    elif sys.platform == 'darwin' and tuple(map(int,  platform.mac_ver()[0].split('.'))) >= (10, 15) and \
-            library == unversioned:
-        library = fallback
-    return library

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -90,7 +90,6 @@ class TLSTests(unittest.TestCase):
         return (
             ('google', 'www.google.com', 443),
             ('package_control', 'packagecontrol.io', 443),
-            ('howsmyssl', 'www.howsmyssl.com', 443),
             ('dh1024', 'dh1024.badtls.io', 10005),
         )
 


### PR DESCRIPTION
MacOS Big Sur had dynamic linker changes. Shared libraries are now stored only in `/System/Library/dyld/dyld_shared_cache_x86_64` and no longer present on the actual file system. This changes makes the `find_library` not return the paths of the libraries such as `find_library("ssl")`