### PR TITLE
Line 695 in asymmetric.py: corrected parameter name

### DIFF
--- a/oscrypto/_openssl/asymmetric.py
+++ b/oscrypto/_openssl/asymmetric.py
@@ -692,7 +692,7 @@ def load_public_key(source):
             source must be a byte string, unicode string or
             asn1crypto.keys.PublicKeyInfo object, not %s
             ''',
-            type_name(public_key)
+            type_name(source)
         ))
 
     if public_key.algorithm == 'dsa':


### PR DESCRIPTION
Resolves the following: UnboundLocalError: local variable 'public_key' referenced before assignment