### PR TITLE
Fix legacy crypto support for OpenSSL 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,8 +166,8 @@ jobs:
       - name: Run test suite
         run: python run.py ci-driver
 
-  build-ubuntu-openssl3:
-    name: Python ${{ matrix.python }} on (Docker) ubuntu-22.04 x64
+  build-ubuntu-openssl3-py3:
+    name: Python 3 on (Docker) ubuntu-22.04 x64
     runs-on: ubuntu-latest
     container: ubuntu:22.04
     steps:
@@ -180,6 +180,22 @@ jobs:
         run: python run.py ci-driver
       - name: Run test suite (cffi)
         run: python run.py ci-driver cffi
+
+  build-ubuntu-openssl3-py2:
+    name: Python 2 on (Docker) ubuntu-22.04 x64
+    runs-on: ubuntu-latest
+    container: ubuntu:22.04
+    steps:
+      - uses: actions/checkout@master
+      - name: Install Python and OpenSSL
+        run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends python2 python-setuptools openssl curl ca-certificates git
+      - name: Install dependencies
+        run: python2 run.py deps
+      - name: Run test suite
+        run: python2 run.py ci-driver
+      - name: Run test suite (cffi)
+        run: python2 run.py ci-driver cffi
+
 
   build-ubuntu-old:
     name: Python ${{ matrix.python }} on ubuntu-18.04 x64

--- a/oscrypto/_openssl/_libcrypto.py
+++ b/oscrypto/_openssl/_libcrypto.py
@@ -44,9 +44,11 @@ libcrypto.OPENSSL_config(null())
 # like PKCS12
 libcrypto_legacy_support = True
 if libcrypto_version_info >= (3, ):
-    if libcrypto.OSSL_PROVIDER_available(null(), "legacy".encode("ascii")):
-        libcrypto.OSSL_PROVIDER_load(null(), "legacy".encode("ascii"))
-    else:
+
+    libcrypto.OSSL_PROVIDER_load(null(), "legacy".encode("ascii"))
+    libcrypto.OSSL_PROVIDER_load(null(), "default".encode("ascii"))
+
+    if libcrypto.OSSL_PROVIDER_available(null(), "legacy".encode("ascii")) == 0:
         libcrypto_legacy_support = False
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -139,6 +139,7 @@ def test_classes():
     from .test_symmetric import SymmetricTests
     from .test_trust_list import TrustListTests
     from .test_init import InitTests
+    from .test_legacy_module import LegacyProviderTests
 
     test_classes = [
         KDFTests,
@@ -147,6 +148,7 @@ def test_classes():
         SymmetricTests,
         TrustListTests,
         InitTests,
+        LegacyProviderTests,
     ]
     if not os.environ.get('OSCRYPTO_SKIP_INTERNET_TESTS'):
         from .test_tls import TLSTests

--- a/tests/test_legacy_module.py
+++ b/tests/test_legacy_module.py
@@ -1,0 +1,55 @@
+# coding: utf-8
+from __future__ import unicode_literals, division, absolute_import, print_function
+
+from oscrypto import backend
+
+from ._unittest_compat import patch
+from .unittest_data import data_decorator
+
+import sys
+import unittest
+
+patch()
+
+if sys.version_info < (3,):
+    byte_cls = str
+else:
+    byte_cls = bytes
+
+_backend = backend()
+
+if _backend == 'openssl':
+    from oscrypto._openssl._libcrypto import libcrypto_legacy_support, libcrypto
+    supports_legacy = libcrypto_legacy_support
+
+    from oscrypto._openssl._libcrypto_ctypes import version_info
+    from oscrypto._ffi import null
+
+
+@data_decorator
+class LegacyProviderTests(unittest.TestCase):
+
+    # OSSL_PROVIDER_available and the legacy provider only exist since OpenSSL 3
+
+    def test_checkLegacy(self):
+        if (_backend != 'openssl' or version_info < (3, )):
+            if (sys.version_info < (2, 7)):
+                # Python 2.6 doesn't support "skipTest", so just return
+                return
+            self.skipTest("This test only makes sense with OpenSSL 3")
+
+        # OSSL_PROVIDER_available does NOT express if a provider can be loaded.
+        # It expresses if a provider has been loaded and can be used.
+
+        is_avail = libcrypto.OSSL_PROVIDER_available(null(), "legacy".encode("ascii"))
+        self.assertEqual(is_avail, libcrypto_legacy_support, "legacy provider loaded but libcrypto claims it's not")
+
+        if not is_avail:
+            # Currently not loaded. See if we can load it
+            # If we can (if "is_avail" is true after this), then oscrypto should have automatically loaded it
+            # to allow the user to use legacy encryptions.
+            libcrypto.OSSL_PROVIDER_load(null(), "legacy".encode("ascii"))
+            libcrypto.OSSL_PROVIDER_load(null(), "default".encode("ascii"))
+            is_avail = libcrypto.OSSL_PROVIDER_available(null(), "legacy".encode("ascii"))
+
+            self.assertEqual(is_avail, libcrypto_legacy_support, "legacy provider should have been loaded")


### PR DESCRIPTION
There seem to be two bugs in the existing code (as reported in #60 )

A) `OSSL_PROVIDER_available` indicates if a provider is loaded - if it is available to be used. Not if it is installed, as in, available to be loaded. That means, it will always be false as in the default config (at least on Ubuntu 22.04) it's not loaded. 
You first need to (try to) load the legacy provider, then check if that was successful. 

Quoting from the OpenSSL commit message that introduced this function: 

    *) Introduced a new function, OSSL_PROVIDER_available(), which can be used
       to check if a named provider is loaded and available.  When called, it
       will also activate all fallback providers if such are still present.
       [Richard Levitte]

B) Once you load any provider (in this case, "legacy"), OpenSSL no longer loads the default provider with all the non-legacy code. You need to load both, one after the other. This bug didn't affect anything in 1.3.0 because due to bug A), the code never actually tried to load the legacy module, at least in my tests. 