### PR TITLE
fix OSError on MacOS 12+

### DIFF
--- a/oscrypto/_mac/_security_cffi.py
+++ b/oscrypto/_mac/_security_cffi.py
@@ -103,6 +103,7 @@ ffi.cdef("""
     SecTransformRef SecSignTransformCreate(SecKeyRef key, CFErrorRef *error);
     SecCertificateRef SecCertificateCreateWithData(CFAllocatorRef allocator, CFDataRef data);
     OSStatus SecCertificateCopyPublicKey(SecCertificateRef certificate, SecKeyRef *key);
+    SecKeyRef SecCertificateCopyKey(SecCertificateRef certificate);
     CFStringRef SecCopyErrorMessageString(OSStatus status, void *reserved);
     OSStatus SecTrustCopyAnchorCertificates(CFArrayRef *anchors);
     CFDataRef SecCertificateCopyData(SecCertificateRef certificate);

--- a/oscrypto/_mac/_security_ctypes.py
+++ b/oscrypto/_mac/_security_ctypes.py
@@ -186,6 +186,11 @@ try:
     ]
     Security.SecCertificateCreateWithData.restype = SecCertificateRef
 
+    Security.SecCertificateCopyKey.argtypes = [
+        SecCertificateRef,
+    ]
+    Security.SecCertificateCopyKey.restype = SecKeyRef
+
     Security.SecCertificateCopyPublicKey.argtypes = [
         SecCertificateRef,
         POINTER(SecKeyRef)

--- a/oscrypto/_mac/asymmetric.py
+++ b/oscrypto/_mac/asymmetric.py
@@ -261,9 +261,12 @@ class Certificate(_CertificateBase):
                 sec_cert_ref = self.sec_certificate_ref
 
             sec_public_key_ref_pointer = new(Security, 'SecKeyRef *')
-            res = Security.SecCertificateCopyPublicKey(sec_cert_ref, sec_public_key_ref_pointer)
-            handle_sec_error(res)
-            sec_public_key_ref = unwrap(sec_public_key_ref_pointer)
+            if osx_version_info >= (10, 14):
+                sec_public_key_ref = Security.SecCertificateCopyKey(sec_cert_ref)
+            else:
+                res = Security.SecCertificateCopyPublicKey(sec_cert_ref, sec_public_key_ref_pointer)
+                handle_sec_error(res)
+                sec_public_key_ref = unwrap(sec_public_key_ref_pointer)
             self._public_key = PublicKey(sec_public_key_ref, self.asn1['tbs_certificate']['subject_public_key_info'])
 
         return self._public_key


### PR DESCRIPTION
add support for SecCertificateCopyKey, which replaces deprecated SecCertificateCopyPublicKey since MacOS 10.14

fixes #56 

https://developer.apple.com/documentation/security/1396096-seccertificatecopypublickey