### PR TITLE
MJ: Fix #75 bug with openssl 3.0.10

### DIFF
--- a/oscrypto/_openssl/_libcrypto_cffi.py
+++ b/oscrypto/_openssl/_libcrypto_cffi.py
@@ -37,7 +37,7 @@ except (AttributeError):
 
 is_libressl = 'LibreSSL' in version_string
 
-version_match = re.search('\\b(\\d\\.\\d\\.\\d[a-z]*)\\b', version_string)
+version_match = re.search('\\b(\\d\\.\\d\\.\\d+[a-z]*)\\b', version_string)
 if not version_match:
     version_match = re.search('(?<=LibreSSL )(\\d\\.\\d(\\.\\d)?)\\b', version_string)
 if not version_match:

--- a/oscrypto/_openssl/_libcrypto_ctypes.py
+++ b/oscrypto/_openssl/_libcrypto_ctypes.py
@@ -40,7 +40,7 @@ except (AttributeError):
 
 is_libressl = 'LibreSSL' in version_string
 
-version_match = re.search('\\b(\\d\\.\\d\\.\\d[a-z]*)\\b', version_string)
+version_match = re.search('\\b(\\d\\.\\d\\.\\d+[a-z]*)\\b', version_string)
 if not version_match:
     version_match = re.search('(?<=LibreSSL )(\\d\\.\\d(\\.\\d)?)\\b', version_string)
 if not version_match:


### PR DESCRIPTION
This PR fixes the regex that breaks oscrypto with openssl 3.0.10 (#75 ).
In adding a `+` in the regex, we allow version numbers of the form `D.D.DD`.
Tested at home, it seems enough to solve the problem.

This would be the clean solution to snowpark-python's problem (https://github.com/snowflakedb/snowpark-python/issues/992)