### PR TITLE
use `importlib` instead of deprecated `imp` module

### DIFF
--- a/dev/_import.py
+++ b/dev/_import.py
@@ -1,11 +1,18 @@
 # coding: utf-8
 from __future__ import unicode_literals, division, absolute_import, print_function
 
-import imp
 import sys
 import os
 
 from . import build_root, package_name, package_root
+
+if sys.version_info < (3, 5):
+    import imp
+else:
+    import importlib
+    import importlib.machinery
+    import importlib.util
+
 
 if sys.version_info < (3,):
     getcwd = os.getcwdu
@@ -34,6 +41,14 @@ def _import_from(mod, path, mod_dir=None, allow_error=False):
         None if not loaded, otherwise the module
     """
 
+    if mod in sys.modules:
+        return sys.modules[mod]
+
+    if mod_dir is None:
+        full_mod = mod
+    else:
+        full_mod = mod_dir
+
     if mod_dir is None:
         mod_dir = mod.replace('.', os.sep)
 
@@ -49,8 +64,22 @@ def _import_from(mod, path, mod_dir=None, allow_error=False):
         path = os.path.join(path, append)
 
     try:
-        mod_info = imp.find_module(mod_dir, [path])
-        return imp.load_module(mod, *mod_info)
+        if sys.version_info < (3, 5):
+            mod_info = imp.find_module(mod_dir, [path])
+            return imp.load_module(mod, *mod_info)
+
+        else:
+            loader_details = (
+                importlib.machinery.SourceFileLoader,
+                importlib.machinery.SOURCE_SUFFIXES
+            )
+            finder = importlib.machinery.FileFinder(path, loader_details)
+            spec = finder.find_spec(full_mod)
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[mod] = module
+            spec.loader.exec_module(module)
+            return module
+
     except ImportError:
         if allow_error:
             raise

--- a/dev/_import.py
+++ b/dev/_import.py
@@ -10,7 +10,7 @@ if sys.version_info < (3, 5):
     import imp
 else:
     import importlib
-    import importlib.machinery
+    import importlib.abc
     import importlib.util
 
 
@@ -18,6 +18,48 @@ if sys.version_info < (3,):
     getcwd = os.getcwdu
 else:
     getcwd = os.getcwd
+
+
+class ModCryptoMetaFinder(importlib.abc.MetaPathFinder):
+    def setup(self):
+        self.modules = {}
+        sys.meta_path.insert(0, self)
+
+    def add_module(self, package_name, package_path):
+        if package_name not in self.modules:
+            self.modules[package_name] = package_path
+
+    def find_spec(self, fullname, path, target=None):
+        name_parts = fullname.split('.')
+        if name_parts[0] not in self.modules:
+            return None
+
+        package = name_parts[0]
+        package_path = self.modules[package]
+
+        fullpath = os.path.join(package_path, *name_parts[1:])
+
+        if os.path.isdir(fullpath):
+            filename = os.path.join(fullpath, "__init__.py")
+            submodule_locations = [fullpath]
+        else:
+            filename = fullpath + ".py"
+            submodule_locations = None
+
+        if not os.path.exists(filename):
+            return None
+
+        return importlib.util.spec_from_file_location(
+            fullname,
+            filename,
+            loader=None,
+            submodule_search_locations=submodule_locations
+        )
+
+
+if sys.version_info >= (3, 5):
+    CUSTOM_FINDER = ModCryptoMetaFinder()
+    CUSTOM_FINDER.setup()
 
 
 def _import_from(mod, path, mod_dir=None, allow_error=False):
@@ -47,7 +89,7 @@ def _import_from(mod, path, mod_dir=None, allow_error=False):
     if mod_dir is None:
         full_mod = mod
     else:
-        full_mod = mod_dir
+        full_mod = mod_dir.replace(os.sep, '.')
 
     if mod_dir is None:
         mod_dir = mod.replace('.', os.sep)
@@ -55,8 +97,11 @@ def _import_from(mod, path, mod_dir=None, allow_error=False):
     if not os.path.exists(path):
         return None
 
-    if not os.path.exists(os.path.join(path, mod_dir)) \
-            and not os.path.exists(os.path.join(path, mod_dir + '.py')):
+    source_path = os.path.join(path, mod_dir, '__init__.py')
+    if not os.path.exists(source_path):
+        source_path = os.path.join(path, mod_dir + '.py')
+
+    if not os.path.exists(source_path):
         return None
 
     if os.sep in mod_dir:
@@ -69,16 +114,12 @@ def _import_from(mod, path, mod_dir=None, allow_error=False):
             return imp.load_module(mod, *mod_info)
 
         else:
-            loader_details = (
-                importlib.machinery.SourceFileLoader,
-                importlib.machinery.SOURCE_SUFFIXES
-            )
-            finder = importlib.machinery.FileFinder(path, loader_details)
-            spec = finder.find_spec(full_mod)
-            module = importlib.util.module_from_spec(spec)
-            sys.modules[mod] = module
-            spec.loader.exec_module(module)
-            return module
+            package = mod.split('.', 1)[0]
+            package_dir = full_mod.split('.', 1)[0]
+            package_path = os.path.join(path, package_dir)
+            CUSTOM_FINDER.add_module(package, package_path)
+
+            return importlib.import_module(mod)
 
     except ImportError:
         if allow_error:

--- a/dev/_import.py
+++ b/dev/_import.py
@@ -19,45 +19,44 @@ if sys.version_info < (3,):
 else:
     getcwd = os.getcwd
 
-
-class ModCryptoMetaFinder(importlib.abc.MetaPathFinder):
-    def setup(self):
-        self.modules = {}
-        sys.meta_path.insert(0, self)
-
-    def add_module(self, package_name, package_path):
-        if package_name not in self.modules:
-            self.modules[package_name] = package_path
-
-    def find_spec(self, fullname, path, target=None):
-        name_parts = fullname.split('.')
-        if name_parts[0] not in self.modules:
-            return None
-
-        package = name_parts[0]
-        package_path = self.modules[package]
-
-        fullpath = os.path.join(package_path, *name_parts[1:])
-
-        if os.path.isdir(fullpath):
-            filename = os.path.join(fullpath, "__init__.py")
-            submodule_locations = [fullpath]
-        else:
-            filename = fullpath + ".py"
-            submodule_locations = None
-
-        if not os.path.exists(filename):
-            return None
-
-        return importlib.util.spec_from_file_location(
-            fullname,
-            filename,
-            loader=None,
-            submodule_search_locations=submodule_locations
-        )
-
-
 if sys.version_info >= (3, 5):
+    class ModCryptoMetaFinder(importlib.abc.MetaPathFinder):
+        def setup(self):
+            self.modules = {}
+            sys.meta_path.insert(0, self)
+
+        def add_module(self, package_name, package_path):
+            if package_name not in self.modules:
+                self.modules[package_name] = package_path
+
+        def find_spec(self, fullname, path, target=None):
+            name_parts = fullname.split('.')
+            if name_parts[0] not in self.modules:
+                return None
+
+            package = name_parts[0]
+            package_path = self.modules[package]
+
+            fullpath = os.path.join(package_path, *name_parts[1:])
+
+            if os.path.isdir(fullpath):
+                filename = os.path.join(fullpath, "__init__.py")
+                submodule_locations = [fullpath]
+            else:
+                filename = fullpath + ".py"
+                submodule_locations = None
+
+            if not os.path.exists(filename):
+                return None
+
+            return importlib.util.spec_from_file_location(
+                fullname,
+                filename,
+                loader=None,
+                submodule_search_locations=submodule_locations
+            )
+
+
     CUSTOM_FINDER = ModCryptoMetaFinder()
     CUSTOM_FINDER.setup()
 

--- a/dev/_import.py
+++ b/dev/_import.py
@@ -56,7 +56,6 @@ if sys.version_info >= (3, 5):
                 submodule_search_locations=submodule_locations
             )
 
-
     CUSTOM_FINDER = ModCryptoMetaFinder()
     CUSTOM_FINDER.setup()
 

--- a/dev/build.py
+++ b/dev/build.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 from __future__ import unicode_literals, division, absolute_import, print_function
 
-import imp
 import os
 import tarfile
 import zipfile
@@ -9,6 +8,7 @@ import zipfile
 import setuptools.sandbox
 
 from . import package_root, package_name, has_tests_package
+from ._import import _import_from
 
 
 def _list_zip(filename):
@@ -45,8 +45,8 @@ def run():
 
     # Trying to call setuptools.sandbox.run_setup(setup, ['--version'])
     # resulted in a segfault, so we do this instead
-    module_info = imp.find_module('version', [os.path.join(package_root, package_name)])
-    version_mod = imp.load_module('%s.version' % package_name, *module_info)
+    package_dir = os.path.join(package_root, package_name)
+    version_mod = _import_from('%s.version' % package_name, package_dir, 'version')
 
     pkg_name_info = (package_name, version_mod.__version__)
     print('Building %s-%s' % pkg_name_info)

--- a/dev/coverage.py
+++ b/dev/coverage.py
@@ -16,6 +16,7 @@ import subprocess
 from fnmatch import fnmatch
 
 from . import package_name, package_root, other_packages
+from ._import import _import_from
 
 if sys.version_info < (3,):
     str_cls = unicode  # noqa
@@ -31,11 +32,6 @@ if sys.version_info < (3, 7):
     Pattern = re._pattern_type
 else:
     Pattern = re.Pattern
-
-if sys.version_info < (3, 5):
-    import imp
-else:
-    import importlib
 
 
 def run(ci=False):
@@ -107,20 +103,7 @@ def _load_package_tests(name):
     if not os.path.exists(package_dir):
         return []
 
-    if sys.version_info < (3, 5):
-        tests_module_info = imp.find_module('tests', [package_dir])
-        tests_module = imp.load_module('%s.tests' % name, *tests_module_info)
-    else:
-        loader_details = (
-            importlib.machinery.SourceFileLoader,
-            importlib.machinery.SOURCE_SUFFIXES
-        )
-        finder = importlib.machinery.FileFinder(package_dir, loader_details)
-        spec = finder.find_spec('tests')
-        test_module = importlib.util.module_from_spec(spec)
-        sys.modules['%s.tests' % name] = test_module
-        spec.loader.exec_module(test_module)
-    return tests_module.test_classes()
+    return _import_from('%s.tests' % name, package_dir, 'tests').test_classes()
 
 
 def _env_info():

--- a/dev/coverage.py
+++ b/dev/coverage.py
@@ -103,7 +103,7 @@ def _load_package_tests(name):
     if not os.path.exists(package_dir):
         return []
 
-    return _import_from('%s.tests' % name, package_dir, 'tests').test_classes()
+    return _import_from('%s_tests' % name, package_dir, 'tests').test_classes()
 
 
 def _env_info():

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -103,8 +103,10 @@ def _import_from(mod, path, mod_dir=None):
             mod_info = imp.find_module(mod_dir, [path])
             return imp.load_module(mod, *mod_info)
         else:
-            mod_info = importlib.machinery.PathFinder().find_spec(mod_dir, [path])
-            return importlib.import_module(mod, *mod_info)
+            spec = importlib.machinery.PathFinder().find_spec(mod_dir, [path])
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[mod] = module
+            spec.loader.exec_module(module)
     except ImportError:
         return None
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -103,7 +103,12 @@ def _import_from(mod, path, mod_dir=None):
             mod_info = imp.find_module(mod_dir, [path])
             return imp.load_module(mod, *mod_info)
         else:
-            spec = importlib.machinery.PathFinder().find_spec(mod_dir, [path])
+            loader_details = (
+                importlib.machinery.SourceFileLoader,
+                importlib.machinery.SOURCE_SUFFIXES
+            )
+            finder = importlib.machinery.FileFinder(path, loader_details)
+            spec = finder.find_spec(mod_dir)
             module = importlib.util.module_from_spec(spec)
             sys.modules[mod] = module
             spec.loader.exec_module(module)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -110,7 +110,6 @@ if sys.version_info >= (3, 5):
                 submodule_search_locations=submodule_locations
             )
 
-
     CUSTOM_FINDER = ModCryptoMetaFinder()
     CUSTOM_FINDER.setup()
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,7 +6,7 @@ import sys
 import unittest
 
 if sys.version_info < (3,):
-    import imp as importlib
+    import imp
 else:
     import importlib
 
@@ -99,7 +99,12 @@ def _import_from(mod, path, mod_dir=None):
         return None
 
     try:
-        return importlib.import_module(mod)
+        if sys.version_info < (3,):
+            mod_info = imp.find_module(mod_dir, [path])
+            return imp.load_module(mod, *mod_info)
+        else:
+            mod_info = importlib.machinery.PathFinder().find_spec(mod_dir, [path])
+            return importlib.import_module(mod, *mod_info)
     except ImportError:
         return None
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -89,6 +89,9 @@ def _import_from(mod, path, mod_dir=None):
         None if not loaded, otherwise the module
     """
 
+    if mod in sys.modules:
+        return sys.modules[mod]
+
     if mod_dir is None:
         mod_dir = mod
 
@@ -112,6 +115,7 @@ def _import_from(mod, path, mod_dir=None):
             module = importlib.util.module_from_spec(spec)
             sys.modules[mod] = module
             spec.loader.exec_module(module)
+            return module
     except ImportError:
         return None
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,7 +5,7 @@ import os
 import sys
 import unittest
 
-if sys.version_info < (3,):
+if sys.version_info < (3, 5):
     import imp
 else:
     import importlib
@@ -99,7 +99,7 @@ def _import_from(mod, path, mod_dir=None):
         return None
 
     try:
-        if sys.version_info < (3,):
+        if sys.version_info < (3, 5):
             mod_info = imp.find_module(mod_dir, [path])
             return imp.load_module(mod, *mod_info)
         else:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -73,44 +73,44 @@ def local_oscrypto():
     return (_asn1crypto_module, _oscrypto_module)
 
 
-class ModCryptoMetaFinder(importlib.abc.MetaPathFinder):
-    def setup(self):
-        self.modules = {}
-        sys.meta_path.insert(0, self)
-
-    def add_module(self, package_name, package_path):
-        if package_name not in self.modules:
-            self.modules[package_name] = package_path
-
-    def find_spec(self, fullname, path, target=None):
-        name_parts = fullname.split('.')
-        if name_parts[0] not in self.modules:
-            return None
-
-        package = name_parts[0]
-        package_path = self.modules[package]
-
-        fullpath = os.path.join(package_path, *name_parts[1:])
-
-        if os.path.isdir(fullpath):
-            filename = os.path.join(fullpath, "__init__.py")
-            submodule_locations = [fullpath]
-        else:
-            filename = fullpath + ".py"
-            submodule_locations = None
-
-        if not os.path.exists(filename):
-            return None
-
-        return importlib.util.spec_from_file_location(
-            fullname,
-            filename,
-            loader=None,
-            submodule_search_locations=submodule_locations
-        )
-
-
 if sys.version_info >= (3, 5):
+    class ModCryptoMetaFinder(importlib.abc.MetaPathFinder):
+        def setup(self):
+            self.modules = {}
+            sys.meta_path.insert(0, self)
+
+        def add_module(self, package_name, package_path):
+            if package_name not in self.modules:
+                self.modules[package_name] = package_path
+
+        def find_spec(self, fullname, path, target=None):
+            name_parts = fullname.split('.')
+            if name_parts[0] not in self.modules:
+                return None
+
+            package = name_parts[0]
+            package_path = self.modules[package]
+
+            fullpath = os.path.join(package_path, *name_parts[1:])
+
+            if os.path.isdir(fullpath):
+                filename = os.path.join(fullpath, "__init__.py")
+                submodule_locations = [fullpath]
+            else:
+                filename = fullpath + ".py"
+                submodule_locations = None
+
+            if not os.path.exists(filename):
+                return None
+
+            return importlib.util.spec_from_file_location(
+                fullname,
+                filename,
+                loader=None,
+                submodule_search_locations=submodule_locations
+            )
+
+
     CUSTOM_FINDER = ModCryptoMetaFinder()
     CUSTOM_FINDER.setup()
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 from __future__ import unicode_literals, division, absolute_import, print_function
 
-import imp
+import importlib
 import os
 import unittest
 
@@ -94,8 +94,7 @@ def _import_from(mod, path, mod_dir=None):
         return None
 
     try:
-        mod_info = imp.find_module(mod_dir, [path])
-        return imp.load_module(mod, *mod_info)
+        return importlib.import_module(mod)
     except ImportError:
         return None
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,9 +1,14 @@
 # coding: utf-8
 from __future__ import unicode_literals, division, absolute_import, print_function
 
-import importlib
 import os
+import sys
 import unittest
+
+if sys.version_info < (3,):
+    import imp as importlib
+else:
+    import importlib
 
 
 __version__ = '1.3.0'


### PR DESCRIPTION
This fixes tests with python 3.12 where the `imp` module was [removed](https://docs.python.org/3.12/whatsnew/3.12.html#removed).

This should fix issue #74.