### PR TITLE
Ignore a libcrypto.dylib with the wrong architecture

### DIFF
--- a/oscrypto/_mac/util.py
+++ b/oscrypto/_mac/util.py
@@ -348,6 +348,10 @@ try:
 
         return bytes_from_buffer(output_buffer)
 
-except (LibraryNotFoundError):
+except (LibraryNotFoundError, OSError):
+    # OpenSSL no longer ships with macOS. If you install Homebrew with arch -x86_64, you end
+    # up with a /usr/local/lib/libcrypto.dylib that will not work with an arm64 Python, and
+    # will fail to load with an OSError. In that case, we should still fall back as if it
+    # were missing.
 
     from .._pkcs12 import pkcs12_kdf


### PR DESCRIPTION
If you install Homebrew with arch -x86_64, you get a /usr/local/lib/libcrypto.dylib that the system Python can't load. We should ignore the resulting error and proceed without that library (which does not ship with the OS any more).

The error looks like:

> OSError: cannot load library '/usr/local/lib/libcrypto.dylib': dlopen(/usr/local/lib/libcrypto.dylib, 0x0002): tried: '/usr/local/lib/libcrypto.dylib' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e' or 'arm64')), '/System/Volumes/Preboot/Cryptexes/OS/usr/local/lib/libcrypto.dylib' (no such file), '/usr/local/lib/libcrypto.dylib' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e' or 'arm64')), '/usr/local/Cellar/openssl@3/3.3.1/lib/libcrypto.3.dylib' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e' or 'arm64')), '/System/Volumes/Preboot/Cryptexes/OS/usr/local/Cellar/openssl@3/3.3.1/lib/libcrypto.3.dylib' (no such file), '/usr/local/Cellar/openssl@3/3.3.1/lib/libcrypto.3.dylib' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e' or 'arm64'))